### PR TITLE
bumped up tornado & watchdog to latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setuptools.setup(
         live-server=live_server.cli:cli
     ''',
     python_requires='>=3.4',
-    install_requires=['Click == 7.0', 'tornado == 5.1.1',
-                      'watchdog == 0.9.0', 'beautifulsoup4 == 4.6.3'],
+    install_requires=['Click == 7.0', 'tornado == 6.4.0',
+                      'watchdog == 4.0.0', 'beautifulsoup4 == 4.6.3'],
 )


### PR DESCRIPTION
Updating the dependency resolves the following error 
`AttributeError: module 'collections' has no attribute 'MutableMapping'`

tornado dependency bumped from 5.1.1 to 6.4.0
watchdog dependency bumped from 0.9.0 to 4.0.0